### PR TITLE
Make text files easier to read as plain text

### DIFF
--- a/Firmware/README.md
+++ b/Firmware/README.md
@@ -1,11 +1,16 @@
 To update the BrickPi3 Firmware
 -------------------------------
-Connect the BrickPi3 to a Raspberry Pi. Assuming you've set up the BrickPi3 software by running the install.sh script, everything should be ready for you to update the firmware.
+
+Connect the BrickPi3 to a Raspberry Pi. Assuming you've set up the BrickPi3
+software by running the install.sh script, everything should be ready for you
+to update the firmware.
 
 Run the firmware update script:
 
     sudo bash /home/pi/Dexter/BrickPi3/Firmware/brickpi3samd_flash_firmware.sh
 
-Towards the bottom of the output (third line from the end), you should see ** Verified OK ** which means the firmware was flashed and verified successfully.
+Towards the bottom of the output (third line from the end), you should see
+`** Verified OK **` which means the firmware was flashed and verified successfully.
 
-You can run the example program "Read_Info.py" in "BrickPi3/Software/Python/Examples" to make sure that the FW version is correct (version "1.1.0" as of writing this).
+You can run the example program `Read_Info.py` in `BrickPi3/Software/Python/Examples`
+to make sure that the FW version is correct (version `1.1.0` as of writing this).

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -3,7 +3,11 @@ License Information
 
 Software License
 ----------------
-**All code (including all scripts, firmware, drivers, examples, and any other software) is released under the [MIT License](http://choosealicense.com/licenses/mit/).**
+
+**All code (including all scripts, firmware, drivers, examples, and any other
+software) is released under the [MIT License].**
+
+[MIT License]: http://choosealicense.com/licenses/mit/
 
 MIT License
 
@@ -27,6 +31,11 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
+
 Hardware License
 ----------------
-**The hardware schematics are released under the [Creative Commons Attribution NonCommercial ShareAlike 4.0 License](https://creativecommons.org/licenses/by-nc-sa/4.0/).**
+
+**The hardware schematics are released under the [Creative Commons Attribution
+NonCommercial ShareAlike 4.0 License][CC4].**
+
+[CC4]: https://creativecommons.org/licenses/by-nc-sa/4.0/

--- a/README.md
+++ b/README.md
@@ -2,27 +2,32 @@ BrickPi3
 ========
 The BrickPi3 connects LEGO Mindstorms with the Raspberry Pi.
 
+
 Installation
 ------------
+
 On Raspbian for Robots, run DI Update to install the latest version.
 
 On Raspbian:
 
 1. Clone this repository onto the Raspberry Pi:
 
-    `sudo git clone http://www.github.com/DexterInd/BrickPi3.git /home/pi/Dexter/BrickPi3`
+        sudo git clone http://www.github.com/DexterInd/BrickPi3.git /home/pi/Dexter/BrickPi3
 
 2. Run the install script:
 
-    `sudo bash /home/pi/Dexter/BrickPi3/Install/install.sh`
+        sudo bash /home/pi/Dexter/BrickPi3/Install/install.sh
 
 3. Reboot the Raspberry Pi to make the settings take effect:
 
-    `sudo reboot`
+        sudo reboot
+
 
 Compatibility
 -------------
+
 The following Lego Sensor and Motors are supported by Python and Scratch:
+
 * Lego Sensors
   * EV3
     * Ultrasonic Sensor
@@ -41,8 +46,18 @@ The following Lego Sensor and Motors are supported by Python and Scratch:
   * EV3 Medium Motor
   * NXT Motor
 
-In addition, the BrickPi3 firmware and Python drivers support custom analog and I2C sensors. Most NXT and EV3 aftermarket sensors should work if you add custom python support. See [this python example for reading custom analog sensors](https://github.com/DexterInd/BrickPi3/blob/master/Software/Python/Examples/Analog_Sensor.py) and [this python example for reading custom I2C sensors](https://github.com/DexterInd/BrickPi3/blob/master/Software/Python/Examples/DI-dTIR.py).
+In addition, the BrickPi3 firmware and Python drivers support custom analog and
+I2C sensors. Most NXT and EV3 aftermarket sensors should work if you add custom
+python support. See [this python example for reading custom analog sensors][ex1]
+and [this python example for reading custom I2C sensors][ex2].
+
+[ex1]: https://github.com/DexterInd/BrickPi3/blob/master/Software/Python/Examples/Analog_Sensor.py
+[ex2]: https://github.com/DexterInd/BrickPi3/blob/master/Software/Python/Examples/DI-dTIR.py
+
 
 License
 -------
-Please review the LICENSE.md file for license information.
+
+Please review the [LICENSE.md] file for license information.
+
+[LICENSE.md]: ./LICENSE.md

--- a/Troubleshooting/README.md
+++ b/Troubleshooting/README.md
@@ -1,8 +1,28 @@
 To troubleshoot the BrickPi3
 ----------------------------
-If the BrickPi3 is not performing as expected, here are some things to try:
-* Check how fast the yellow LED is flashing. If it's flashing 1 time per second, the battery voltage is good (at least 7.2v). If it's flashing twice per second, the battery voltage is adequate, but not great (less than 7.2v). If it's flashing 4 times per second, the battery voltage is too low, and the motors are automatically disabled.
-* Ensure adequate voltage for running the BrickPi3 and Raspberry Pi. If the battery voltage is below 6.8v, the motors might be automatically disabled in attempt to keep the Raspberry Pi from crashing due to dead batteries. If the battery voltage is below about 6.5v, the Raspberry Pi might not be getting adequate power. Instead of running on batteries, you can connect 5v directly to the Raspberry Pi using the micro-USB power input connector to ensure that the Raspberry Pi will be powered adequately in case your batteries are dead.
-* Run the troubleshooting script "all_tests.sh". Look through the output to see if there's anything unexpected. If you don't find the problem, you can upload the log.txt file from the desktop (/home/pi/Desktop/log.txt) to the [forums](http://forum.dexterindustries.com/c/brickpi) and ask for help (please give a clear description of the problem you're experiencing). You can run the troubleshooting script by running this:
 
-    `sudo bash /home/pi/Dexter/BrickPi3/Troubleshooting/all_tests.sh`
+If the BrickPi3 is not performing as expected, here are some things to try:
+
+* Check how fast the yellow LED is flashing. If it's flashing 1 time per
+  second, the battery voltage is good (at least 7.2v). If it's flashing twice
+  per second, the battery voltage is adequate, but not great (less than 7.2v).
+  If it's flashing 4 times per second, the battery voltage is too low, and the
+  motors are automatically disabled.
+
+* Ensure adequate voltage for running the BrickPi3 and Raspberry Pi. If the
+  battery voltage is below 6.8v, the motors might be automatically disabled in
+  attempt to keep the Raspberry Pi from crashing due to dead batteries. If the
+  battery voltage is below about 6.5v, the Raspberry Pi might not be getting
+  adequate power. Instead of running on batteries, you can connect 5v directly
+  to the Raspberry Pi using the micro-USB power input connector to ensure that
+  the Raspberry Pi will be powered adequately in case your batteries are dead.
+
+* Run the troubleshooting script `all_tests.sh`. Look through the output to
+  see if there's anything unexpected. If you don't find the problem, you can
+  upload the `log.txt` file from the desktop (`/home/pi/Desktop/log.txt`) to
+  the [forums] and ask for help (please give a clear description of the problem
+  you're experiencing). You can run the troubleshooting script by running this:
+
+        sudo bash /home/pi/Dexter/BrickPi3/Troubleshooting/all_tests.sh
+
+[forums]: http://forum.dexterindustries.com/c/brickpi


### PR DESCRIPTION
The default editor on Raspbian for Robots does not wrap lines, so make stuff as pretty as possible for this.