### PR TITLE
Rename set_motor_speed to set_motor_power

### DIFF
--- a/Firmware/README.md
+++ b/Firmware/README.md
@@ -1,6 +1,6 @@
 To update the BrickPi3 Firmware
 -------------------------------
-Connect the BrickPi3 to a Raspberry Pi. Assuming you've set up the BrickPi3 software by running the install.sh script, everything should be ready for you to update the firmware.
+Connect the BrickPi3 to a Raspberry Pi. Assuming you've set up the BrickPi3 software by running DI Update on Raspbian for Robots (or the install.sh script on Raspbian), everything should be ready for you to update the firmware.
 
 Run the firmware update script:
 

--- a/Software/Python/Examples/LEGO-Motor_DPS.py
+++ b/Software/Python/Examples/LEGO-Motor_DPS.py
@@ -24,7 +24,7 @@ BP = brickpi3.BrickPi3() # Create an instance of the BrickPi3 class. BP will be 
 try:
     BP.offset_motor_encoder(BP.PORT_A, BP.get_motor_encoder(BP.PORT_A)[0]) # reset encoder A
     BP.offset_motor_encoder(BP.PORT_D, BP.get_motor_encoder(BP.PORT_D)[0]) # reset encoder D
-    BP.set_motor_speed(BP.PORT_D, -128)                                    # float motor D
+    BP.set_motor_power(BP.PORT_D, BP.MOTOR_FLOAT)                                    # float motor D
     #BP.set_motor_limits(BP.PORT_A, 50)                                     # optionally set a power limit
     while True:
         # BP.get_motor_encoder function return a list of 2 values

--- a/Software/Python/Examples/LEGO-Motor_Position.py
+++ b/Software/Python/Examples/LEGO-Motor_Position.py
@@ -24,7 +24,7 @@ BP = brickpi3.BrickPi3() # Create an instance of the BrickPi3 class. BP will be 
 try:
     BP.offset_motor_encoder(BP.PORT_A, BP.get_motor_encoder(BP.PORT_A)[0]) # reset encoder A
     BP.offset_motor_encoder(BP.PORT_D, BP.get_motor_encoder(BP.PORT_D)[0]) # reset encoder D
-    BP.set_motor_speed(BP.PORT_D, -128)                                    # float motor D
+    BP.set_motor_power(BP.PORT_D, BP.MOTOR_FLOAT)                          # float motor D
     #BP.set_motor_limits(BP.PORT_A, 25)                                     # optionally set a power limit
     while True:
         # Each of the following BP.get_motor_encoder functions return a list of 2 values

--- a/Software/Python/Examples/LEGO-Motor_Speed.py
+++ b/Software/Python/Examples/LEGO-Motor_Speed.py
@@ -27,7 +27,7 @@ try:
         #     The first item in the list is the value (what we want to use to control motor C's speed).
         #     The second item in the list is the error value (should be equal to BP.SUCCESS if the value was read successfully)
         speed = BP.get_motor_encoder(BP.PORT_B)[0]
-        BP.set_motor_speed(BP.PORT_C, speed)
+        BP.set_motor_power(BP.PORT_C, speed)
         
         time.sleep(0.02)  # delay for 0.02 seconds (20ms) to reduce the Raspberry Pi CPU load.
 

--- a/Software/Python/Examples/LEGO-Motors.py
+++ b/Software/Python/Examples/LEGO-Motors.py
@@ -45,10 +45,10 @@ try:
             adder = 1
         
         # Set the motor speed for all four motors
-        BP.set_motor_speed(BP.PORT_A, speed)
-        BP.set_motor_speed(BP.PORT_B, speed)
-        BP.set_motor_speed(BP.PORT_C, speed)
-        BP.set_motor_speed(BP.PORT_D, speed)
+        BP.set_motor_power(BP.PORT_A, speed)
+        BP.set_motor_power(BP.PORT_B, speed)
+        BP.set_motor_power(BP.PORT_C, speed)
+        BP.set_motor_power(BP.PORT_D, speed)
         
         # Each of the following BP.get_motor_encoder functions return a list of 2 values
         #     The first item in the list is the value (what we want to display).

--- a/Software/Python/Projects/BalanceBot.py
+++ b/Software/Python/Projects/BalanceBot.py
@@ -230,8 +230,8 @@ try:
         if powerRight < -100:
             powerRight = -100
         
-        BP.set_motor_speed(PORT_MOTOR_LEFT , powerLeft)
-        BP.set_motor_speed(PORT_MOTOR_RIGHT, powerRight)
+        BP.set_motor_power(PORT_MOTOR_LEFT , powerLeft)
+        BP.set_motor_power(PORT_MOTOR_RIGHT, powerRight)
         
         if (CurrentTime - tMotorPosOK) > TIME_FALL_LIMIT:
             print("Oh no! Robot fell. Exiting.")

--- a/Software/Python/brickpi3.py
+++ b/Software/Python/brickpi3.py
@@ -61,6 +61,8 @@ class BrickPi3(object):
     PORT_C = 2
     PORT_D = 3
     
+    MOTOR_FLOAT = -128
+    
     SensorType = [0, 0, 0, 0]
     I2CInBytes = [0, 0, 0, 0]
     
@@ -90,11 +92,11 @@ class BrickPi3(object):
         READ_SENSOR_3,
         READ_SENSOR_4,
         
-        WRITE_MOTOR_SPEED = 28,
-        WRITE_MOTOR_A_SPEED = 28,
-        WRITE_MOTOR_B_SPEED,
-        WRITE_MOTOR_C_SPEED,
-        WRITE_MOTOR_D_SPEED,
+        WRITE_MOTOR_POWER = 28,
+        WRITE_MOTOR_A_POWER = 28,
+        WRITE_MOTOR_B_POWER,
+        WRITE_MOTOR_C_POWER,
+        WRITE_MOTOR_D_POWER,
         
         WRITE_MOTOR_POSITION = 32,
         WRITE_MOTOR_A_POSITION = 32,
@@ -250,11 +252,12 @@ class BrickPi3(object):
     SENSOR_ERROR = 2
     SENSOR_TYPE_ERROR = 3
     
-    def __init__(self, addr = 1, detect = True): # Configure for the BrickPi. Optionally set the address (default to 1).
+    def __init__(self, addr = 1, detect = True): # Configure for the BrickPi. Optionally set the address (default to 1). Optionally disable detection (default to detect).
         """
         Do any necessary configuration, and optionally detect the BrickPi3
         
         Optionally set the SPI address to something other than 1
+        Optionally disable the detection of the BrickPi3 hardware. This can be used for debugging and testing when the BrickPi3 would otherwise not pass the detection tests.
         """
         
         # note these two lines were a temporary work-around for older Raspbian For Robots.
@@ -783,20 +786,16 @@ class BrickPi3(object):
         
         return 0, self.SENSOR_TYPE_ERROR #"Error, sensor not configured or not supported."#int(0) # not configured
     
-    def set_motor_speed(self, port, speed):
+    def set_motor_power(self, port, power):
         """
-        Set the motor speed in percent
+        Set the motor power in percent
         
         Keyword arguments:
         port -- The Motor port
-        speed -- The Speed from -100 to 100
+        power -- The Power from -100 to 100
         """
-        outArray = [self.SPI_Address, (self.BPSPI_MESSAGE_TYPE.WRITE_MOTOR_SPEED + port), int(speed)]
+        outArray = [self.SPI_Address, (self.BPSPI_MESSAGE_TYPE.WRITE_MOTOR_POWER + port), int(power)]
         self.spi_transfer_array(outArray)
-    
-    #def set_tank_drive(self, ):
-    #    self.set_motor_speed(port, speed)
-    #    self.set_motor_speed(port, speed)
     
     def set_motor_position(self, port, position):
         """
@@ -905,10 +904,10 @@ class BrickPi3(object):
         self.set_sensor_type(self.PORT_4, self.SENSOR_TYPE.NONE)
         
         # turn off all motors
-        self.set_motor_speed(self.PORT_A, -128)
-        self.set_motor_speed(self.PORT_B, -128)
-        self.set_motor_speed(self.PORT_C, -128)
-        self.set_motor_speed(self.PORT_D, -128)
+        self.set_motor_power(self.PORT_A, self.MOTOR_FLOAT)
+        self.set_motor_power(self.PORT_B, self.MOTOR_FLOAT)
+        self.set_motor_power(self.PORT_C, self.MOTOR_FLOAT)
+        self.set_motor_power(self.PORT_D, self.MOTOR_FLOAT)
         
         # return the LED to the control of the FW
         self.set_led(-1)

--- a/Software/Scratch/BrickPi3Scratch.py
+++ b/Software/Scratch/BrickPi3Scratch.py
@@ -286,9 +286,9 @@ def handle_BrickPi_msg(msg):
                 #    incoming_motor_target = "target error"
             
             if incoming_motor_target != "target error":
-                BP3.set_motor_speed(port, incoming_motor_target)
+                BP3.set_motor_power(port, incoming_motor_target)
             else:
-                BP3.set_motor_speed(port, 0)  
+                BP3.set_motor_power(port, 0)  
         else:
             if en_debug:
                 print("Motor position {}".format(incoming_motor_target))
@@ -301,7 +301,7 @@ def handle_BrickPi_msg(msg):
             if incoming_motor_target != "target error":
                 BP3.set_motor_position(port, incoming_motor_target)
             else:
-                BP3.set_motor_speed(port, 0)
+                BP3.set_motor_power(port, 0)
 
         return_dict["Motor Target {}".format(incoming_motor_port.upper())] = incoming_motor_target
 


### PR DESCRIPTION
There has been some confusion regarding the name "set_motor_speed",
since it sets the raw PWM power, not the regulated speed. The name has
been changed to "set_motor_power" to hopefully make it less confusing.
Functionally it is identical. It sets the motor PWM power on a scale of
-100 to 100, with 1% precision. Setting to -128 (or using the
MOTOR_FLOAT constant) floats the motor (disables it without passive or
active braking).