### PR TITLE
Bring BricKuber project to Python3

### DIFF
--- a/Projects/BricKuber/BricKuber.py
+++ b/Projects/BricKuber/BricKuber.py
@@ -62,7 +62,7 @@ try:
 
 except KeyboardInterrupt: # except the program gets interrupted by Ctrl+C on the keyboard.
     Cuber.BP.reset_all()        
-except Exception, e:
+except Exception as e:
     print("Error: " + str(e))
 
 # Unconfigure the sensors, disable the motors, and restore the LED to the control of the BrickPi3 firmware.

--- a/Projects/BricKuber/README.md
+++ b/Projects/BricKuber/README.md
@@ -2,6 +2,10 @@
 
 This project is for a robot that solves a Rubik's cube, using LEGO Mindstorms and the [Dexter Industries BrickPi3.](https://www.dexterindustries.com/brickpi/)  
 
+The project has been updated in March 2021 to bring it to Python3 as some of the dependencies are no longer available in Python2. It has not been fully tested unfortunately.
+
+
+
 ## Software
 Install dependencies by running the install_brickuber.sh setup script:
 

--- a/Projects/BricKuber/install_brickuber.sh
+++ b/Projects/BricKuber/install_brickuber.sh
@@ -2,15 +2,17 @@
 
 sudo apt-get update
 
+# opencv-python from piwheels: https://www.piwheels.org/project/opencv-python/
+sudo apt -y install libaom0 libatk-bridge2.0-0 libatk1.0-0 libatlas3-base libatspi2.0-0 libavcodec58 libavformat58 libavutil56 libbluray2 libcairo-gobject2 libcairo2 libchromaprint1 libcodec2-0.8.1 libcroco3 libdatrie1 libdrm2 libepoxy0 libfontconfig1 libgdk-pixbuf2.0-0 libgfortran5 libgme0 libgraphite2-3 libgsm1 libgtk-3-0 libharfbuzz0b libilmbase23 libjbig0 libmp3lame0 libmpg123-0 libogg0 libopenexr23 libopenjp2-7 libopenmpt0 libopus0 libpango-1.0-0 libpangocairo-1.0-0 libpangoft2-1.0-0 libpixman-1-0 librsvg2-2 libshine3 libsnappy1v5 libsoxr0 libspeex1 libssh-gcrypt-4 libswresample3 libswscale5 libthai0 libtheora0 libtiff5 libtwolame0 libva-drm2 libva-x11-2 libva2 libvdpau1 libvorbis0a libvorbisenc2 libvorbisfile3 libvpx5 libwavpack1 libwayland-client0 libwayland-cursor0 libwayland-egl1 libwebp6 libwebpmux3 libx264-155 libx265-165 libxcb-render0 libxcb-shm0 libxcomposite1 libxcursor1 libxdamage1 libxfixes3 libxi6 libxinerama1 libxkbcommon0 libxrandr2 libxrender1 libxvidcore4 libzvbi0
+sudo pip3 install opencv-python
+
 # install rubiks-cube-tracker
-sudo apt-get install python-pip python-opencv -y
-sudo pip install git+https://github.com/dwalton76/rubiks-cube-tracker.git
+sudo pip3 install git+https://github.com/dwalton76/rubiks-cube-tracker.git
 
 # install rubiks-color-resolver
 sudo pip3 install scikit-learn
-sudo apt-get install python3-pip -y
 sudo pip3 install git+https://github.com/dwalton76/rubiks-color-resolver.git
 
 # install kociemba
 sudo apt-get install libffi-dev -y
-sudo pip install kociemba
+sudo pip3 install kociemba


### PR DESCRIPTION
Since Kociemba is now only available in Python3, the whole project needs an update.
Of course, it uses the 'commands' module which is deprecated in python3. 

As it is, the project has not been fully tested with the updated changes.